### PR TITLE
installer fixer

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -13,7 +13,10 @@ const config: ForgeConfig = {
         bin: 'HBK Device Discovery',
         executableName: 'HBK Device Discovery',
         icon: './src/assets/hbk-logo.ico',
-        setupIcon: './src/assets/hbk-logo.ico'
+        setupIcon: './src/assets/hbk-logo.ico',
+        shortcutName: 'HBK Device Discovery',
+        createStartMenuShortcut: true,
+        createDesktopShortcut: true
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-scan",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-scan",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@electron/fuses": "^1.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ let scanner: HBKScanner | null = null
 
 // Electron setup
 const createWindow = (): void => {
+  if (require('electron-squirrel-startup')) app.quit()
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,


### PR DESCRIPTION
- Fixes the double window after the set-up.exe is ran on windows.
- The App can now be found by the windows search bar
- An Icon shortcut is added to the desktop